### PR TITLE
Fix unit test and bump circle.yml to 1.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,8 +20,8 @@ dependencies:
   pre:
     - sudo apt-get remove --purge golang
     - sudo rm -rf /usr/local/go/
-    - cd ~/download_cache && wget --no-clobber 'https://storage.googleapis.com/golang/go1.5.3.linux-amd64.tar.gz'
-    - cd ~/download_cache && sudo tar -xzf go1.5.3.linux-amd64.tar.gz -C /usr/local
+    - cd ~/download_cache && wget --no-clobber 'https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz'
+    - cd ~/download_cache && sudo tar -xzf go1.8.linux-amd64.tar.gz -C /usr/local
     - cd ~/download_cache && wget --no-clobber 'https://github.com/Masterminds/glide/releases/download/0.8.3/glide-0.8.3-linux-amd64.tar.gz'
     - cd ~/download_cache && tar -xzf glide-0.8.3-linux-amd64.tar.gz
     - cd ~/download_cache && sudo cp linux-amd64/glide /usr/local/bin/glide

--- a/remoteconfig_test.go
+++ b/remoteconfig_test.go
@@ -616,7 +616,8 @@ func (s *RemoteConfigSuite) TestReadJSONValidateEmbeddedStruct() {
 
 	c := &SampleConfig{}
 	err := ReadJSONValidate(cfgBuffer, c)
-	assert.EqualError(s.T(), err, "Failed to decode JSON, with error, json: cannot unmarshal string into Go value of type int64")
+	assert.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "Failed to decode JSON")
 }
 
 func (s *RemoteConfigSuite) TestReadJSONValidateInvalidJSON() {


### PR DESCRIPTION
Not sure the best way to workaround this one, but this is the test output that I get with go 1.8:

```
$ go test ./...
--- FAIL: TestReadJSONValidateEmbeddedStruct (0.00s)
        Error Trace:    remoteconfig_test.go:619
	Error:      	Error message not equal:
	            	expected: "Failed to decode JSON, with error, json: cannot unmarshal string into Go value of type int64"
	            	received: "Failed to decode JSON, with error, json: cannot unmarshal string into Go struct field SampleConfig.embedded_int of type int64"
--- FAIL: TestRemoteConfigSuite (0.00s)
FAIL
FAIL	github.com/zencoder/go-remote-config	0.028s
```

The error message has changed, so I changed the test to just be a "contains" check to better future-proof it.